### PR TITLE
Added custom advisor example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-*/target
+target

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+# [0.0.2] - 2025-11-05
+
+- Added Live-check Custom Advisor Example ([#5](https://github.com/open-telemetry/opentelemetry-weaver-examples/pull/11) by @jerbly)
+
 # [0.0.1] - 2025-10-18
 
 - Initial release of OpenTelemetry Weaver Examples - Basic Usage Example ([#4](https://github.com/open-telemetry/opentelemetry-weaver-examples/pull/4) by @jerbly)

--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ Install weaver by following the instructions from the [release](https://github.c
   - It defines a simple model dependent on the OpenTelemetry Semantic Conventions.
   - It shows how to generate docs and code, check and resolve the model, and use live-check with a sample application.
 
+- [Live-check Custom Advisor](custom_advisor/README.md)
+  - This example shows how to create and use a custom advisor with OpenTelemetry Weaver Live-check.
+  - It demonstrates implementing custom validation logic using Rego policies.
+  - It shows how to validate telemetry data against custom annotations in your semantic convention model.
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/custom_advisor/README.md
+++ b/custom_advisor/README.md
@@ -1,0 +1,83 @@
+# Live-check Custom Advisor Example
+
+## Description
+
+This example shows how to create and use a custom advisor with OpenTelemetry Weaver Live-check. A custom advisor allows you to implement your own validation logic for telemetry data against your semantic convention model.
+
+## Prerequisites
+
+Weaver version 0.19.0+ must be installed and available on your PATH.
+
+## The Model
+
+The semantic convention model is defined in [model/example.yaml](model/example.yaml). It defines a counter metric called `example.counter` with an attribute `example.name` that has a custom annotation:
+
+```yaml
+annotations:
+  live_check:
+    case: upper
+```
+
+This annotation specifies that the `example.name` attribute value must be UPPERCASE. It is used by the policy to validate incoming telemetry data.
+
+## The Sample Data
+
+The sample telemetry data is in [samples/metrics.json](samples/metrics.json) and contains two metric data points:
+
+1. **Valid data point**: Has `example.name` set to `"ID1234"` (uppercase) - this should pass validation
+2. **Invalid data point**: Has `example.name` set to `"lowercaseid"` (lowercase) - this should fail validation
+
+## The Policy
+
+The custom advisor policy is implemented in Rego and located at [policies/live_check_advice/upper.rego](policies/live_check_advice/upper.rego).
+
+The policy checks:
+1. If the attribute has the `live_check.case: upper` annotation in the model
+2. If the attribute value is a string
+3. If the value is not entirely uppercase
+
+When these conditions are met, it produces a "violation" level advice with the type `invalid_value_case`, providing a clear message about which attribute value failed the uppercase requirement.
+
+## Run the example
+```shell
+cd custom_advisor
+
+weaver registry live-check -r model --input-source samples/metrics.json --advice-policies policies
+```
+
+The output shows each metric data point with its attributes, and any violations found:
+
+```
+Metric example.counter `counter`, `1`
+    Data point 17
+        example.name = ID1234
+
+Metric example.counter `counter`, `1`
+    Data point 18
+        example.name = lowercaseid
+            - [violation] Value 'lowercaseid' on attribute 'example.name' must be uppercase
+
+Samples
+  - total: 6
+  - by type:
+    - attribute: 2
+    - data_point: 2
+    - metric: 2
+  - by highest advice level:
+    - no advice: 5
+    - violation: 1
+
+Advisories given
+  - total: 1
+  - advice level:
+    - violation: 1
+  - advice type:
+    - invalid_value_case: 1
+  - advice message:
+    - Value 'lowercaseid' on attribute 'example.name' must be uppercase: 1
+
+Registry coverage
+  - entities seen: 100.0%
+```
+
+The first metric with `"ID1234"` passes validation (uppercase), while the second metric with `"lowercaseid"` triggers a violation. The summary shows that 1 out of 6 samples had a violation, and the registry coverage is 100%.

--- a/custom_advisor/model/example.yaml
+++ b/custom_advisor/model/example.yaml
@@ -1,0 +1,17 @@
+groups:
+  - id: metric.example_counter
+    type: metric
+    metric_name: example.counter
+    stability: stable
+    brief: A counter of the number of messages processed.
+    instrument: counter
+    unit: "1"
+    attributes:
+      - id: example.name
+        type: string
+        brief: A name identifier. Must be UPPERCASE.
+        stability: stable
+        examples: ["EXAMPLE", "ID123"]
+        annotations:
+          live_check:
+            case: upper

--- a/custom_advisor/policies/live_check_advice/upper.rego
+++ b/custom_advisor/policies/live_check_advice/upper.rego
@@ -1,0 +1,27 @@
+package live_check_advice
+
+import rego.v1
+
+# If the annotation is set to "upper", check that the attribute value is uppercase
+deny contains make_advice(advice_type, advice_level, advice_context, message) if {
+    input.sample.attribute.value != null
+    input.registry_attribute.annotations.live_check.case == "upper"
+    is_string(input.sample.attribute.value)
+    not input.sample.attribute.value == upper(input.sample.attribute.value)
+    advice_type := "invalid_value_case"
+    advice_level := "violation"
+    advice_context := {"attribute_name": input.sample.attribute.name,
+                       "attribute_value": input.sample.attribute.value}
+    message := sprintf(
+        "Value '%s' on attribute '%s' must be uppercase",
+        [input.sample.attribute.value, input.sample.attribute.name],
+    )
+}
+
+make_advice(advice_type, advice_level, advice_context, message) := {
+	"type": "advice",
+	"advice_type": advice_type,
+	"advice_level": advice_level,
+	"advice_context": advice_context,
+	"message": message,
+}

--- a/custom_advisor/samples/metrics.json
+++ b/custom_advisor/samples/metrics.json
@@ -1,0 +1,38 @@
+[
+    {
+        "metric": {
+            "data_points": [
+                {
+                    "attributes": [
+                        {
+                            "name": "example.name",
+                            "value": "ID1234"
+                        }
+                    ],
+                    "value": 17
+                }
+            ],
+            "instrument": "counter",
+            "name": "example.counter",
+            "unit": "1"
+        }
+    },
+    {
+        "metric": {
+            "data_points": [
+                {
+                    "attributes": [
+                        {
+                            "name": "example.name",
+                            "value": "lowercaseid"
+                        }
+                    ],
+                    "value": 18
+                }
+            ],
+            "instrument": "counter",
+            "name": "example.counter",
+            "unit": "1"
+        }
+    }
+]


### PR DESCRIPTION
Added an example: Annotation-driven live-check custom advisor.

This example shows how to create and use a custom advisor with OpenTelemetry Weaver Live-check. A custom advisor allows you to implement your own validation logic for telemetry data against your semantic convention model.
