### PR TITLE
Fix capitalization of OTel in model attributes

### DIFF
--- a/basic/model/attributes.yaml
+++ b/basic/model/attributes.yaml
@@ -14,7 +14,7 @@ groups:
 
   - id: registry.otel_sdk
     type: attribute_group
-    display_name: Otel Attributes
+    display_name: OTel Attributes
     brief: Attributes used by the OpenTelemetry SDK.
     attributes:
       - ref: service.name


### PR DESCRIPTION
This commit fixes the capitalization of OTel in the model attributes of the basic example.