### PR TITLE
Update reference to otel-desktop-viewer

### DIFF
--- a/basic/README.md
+++ b/basic/README.md
@@ -42,7 +42,7 @@ Like the documentation, Weaver uses jinja templates to create code. In this case
 
 It's useful to see what your telemetry, as defined in your model, will look like in observability tools. `emit` generates OTLP with example data for each signal defined in your model. 
 
-To visualize the generated data, an example tool is [`otel-desktop-viewer`](https://github.com/CtrlSpice/otel-desktop-viewer) - a CLI tool for receiving OpenTelemetry Traces localy:
+To visualize the generated data, an example tool is [`otel-desktop-viewer`](https://github.com/CtrlSpice/otel-desktop-viewer) - a CLI tool for receiving OpenTelemetry Traces locally:
 
 `otel-desktop-viewer --browser-port 8001`
 

--- a/basic/README.md
+++ b/basic/README.md
@@ -42,7 +42,7 @@ Like the documentation, Weaver uses jinja templates to create code. In this case
 
 It's useful to see what your telemetry, as defined in your model, will look like in observability tools. `emit` generates OTLP with example data for each signal defined in your model. 
 
-To visualize the generated data, an example tool is [`otel-desktop-viewer`](https://github.com/CtrlSpice/otel-desktop-viewer`otel-desktop-viewer) - a CLI tool for receiving OpenTelemetry Traces localy:
+To visualize the generated data, an example tool is [`otel-desktop-viewer`](https://github.com/CtrlSpice/otel-desktop-viewer) - a CLI tool for receiving OpenTelemetry Traces localy:
 
 `otel-desktop-viewer --browser-port 8001`
 

--- a/basic/README.md
+++ b/basic/README.md
@@ -42,9 +42,11 @@ Like the documentation, Weaver uses jinja templates to create code. In this case
 
 It's useful to see what your telemetry, as defined in your model, will look like in observability tools. `emit` generates OTLP with example data for each signal defined in your model. 
 
-`otel-desktop-viewer --browser 8001`
+To visualize the generated data, an example tool is [`otel-desktop-viewer`](https://github.com/CtrlSpice/otel-desktop-viewer`otel-desktop-viewer) - a CLI tool for receiving OpenTelemetry Traces localy:
 
-In another shell:
+`otel-desktop-viewer --browser-port 8001`
+
+Then in another shell:
 
 `weaver registry emit -r model`
 


### PR DESCRIPTION
The `otel-desktop-viewer` command line parameter for the port has changed in v0.2.5 from `browser` to `browser-port`.

Also I belive the tool deserves a short introduction, as it isn't referenced anywhere else.