### PR TITLE
Switch to latest release for setup-weaver

### DIFF
--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Weaver
-        uses: open-telemetry/weaver/.github/actions/setup-weaver@69132efc9896446f8be65c652c27149d028ee62e # main
+        uses: open-telemetry/weaver/.github/actions/setup-weaver@v0.23.0
 
       - name: Generate documentation
         run: |

--- a/.github/workflows/check-generated-code.yml
+++ b/.github/workflows/check-generated-code.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Weaver
-        uses: open-telemetry/weaver/.github/actions/setup-weaver@69132efc9896446f8be65c652c27149d028ee62e # main
+        uses: open-telemetry/weaver/.github/actions/setup-weaver@v0.23.0
 
       - name: Generate Rust code
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Setup Weaver
-        uses: open-telemetry/weaver/.github/actions/setup-weaver@69132efc9896446f8be65c652c27149d028ee62e # main
+        uses: open-telemetry/weaver/.github/actions/setup-weaver@v0.23.0
 
       - name: Build
         run: make -C basic build
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Weaver
-        uses: open-telemetry/weaver/.github/actions/setup-weaver@69132efc9896446f8be65c652c27149d028ee62e # main
+        uses: open-telemetry/weaver/.github/actions/setup-weaver@v0.23.0
 
       - name: Check model
         run: make -C basic check-model
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Weaver
-        uses: open-telemetry/weaver/.github/actions/setup-weaver@69132efc9896446f8be65c652c27149d028ee62e # main
+        uses: open-telemetry/weaver/.github/actions/setup-weaver@v0.23.0
 
       - name: Check generated code
         run: make -C basic check-generated
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Weaver
-        uses: open-telemetry/weaver/.github/actions/setup-weaver@69132efc9896446f8be65c652c27149d028ee62e # main
+        uses: open-telemetry/weaver/.github/actions/setup-weaver@v0.23.0
 
       - name: Check generated docs
         run: make -C basic check-generated-docs
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Weaver
-        uses: open-telemetry/weaver/.github/actions/setup-weaver@69132efc9896446f8be65c652c27149d028ee62e # main
+        uses: open-telemetry/weaver/.github/actions/setup-weaver@v0.23.0
 
       - name: Check model
         run: make -C custom_advisor check-model

--- a/.github/workflows/validate-examples.yml
+++ b/.github/workflows/validate-examples.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Weaver
-        uses: open-telemetry/weaver/.github/actions/setup-weaver@69132efc9896446f8be65c652c27149d028ee62e # main
+        uses: open-telemetry/weaver/.github/actions/setup-weaver@v0.23.0
 
       - name: Check model
         run: weaver registry check -r ./basic/model --diagnostic-format gh_workflow_command
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Weaver
-        uses: open-telemetry/weaver/.github/actions/setup-weaver@69132efc9896446f8be65c652c27149d028ee62e # main
+        uses: open-telemetry/weaver/.github/actions/setup-weaver@v0.23.0
 
       - name: Check model
         run: weaver registry check -r ./custom_advisor/model


### PR DESCRIPTION
Switched from `main` to `0.23.0` for setup-weaver action to avoid the renovate churn. Renovate will now track each release of weaver rather than each merge to main.