### PR TITLE
Add live-check actions example workflow

### DIFF
--- a/.github/workflows/live-check-basic.yml
+++ b/.github/workflows/live-check-basic.yml
@@ -1,0 +1,45 @@
+name: Live Check Basic Example
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/live-check-basic.yml'
+      - 'basic/**'
+
+permissions:
+  contents: read
+
+jobs:
+  live-check-basic:
+    name: Live Check Basic Example
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+
+      - name: Setup Weaver
+        uses: open-telemetry/weaver/.github/actions/setup-weaver@adcf6fda79c3df1cb537669442aef753b7019777 # v0.24.2
+
+      - name: Build basic example
+        run: make -C basic build
+
+      - name: Start live-check
+        id: live-check
+        uses: open-telemetry/weaver/.github/actions/weaver-live-check-start@adcf6fda79c3df1cb537669442aef753b7019777 # v0.24.2
+        with:
+          registry: ./basic/model
+
+      - name: Run basic example
+        env:
+          OTEL_EXPORTER_OTLP_ENDPOINT: ${{ steps.live-check.outputs.otlp-grpc-endpoint }}
+        run: cargo run --manifest-path basic/Cargo.toml -- "Hello, World!"
+
+      - name: Stop live-check
+        if: always()
+        uses: open-telemetry/weaver/.github/actions/weaver-live-check-stop@adcf6fda79c3df1cb537669442aef753b7019777 # v0.24.2
+        with:
+          fail-on: violation

--- a/.github/workflows/live-check-basic.yml
+++ b/.github/workflows/live-check-basic.yml
@@ -39,7 +39,19 @@ jobs:
         run: cargo run --manifest-path basic/Cargo.toml -- "Hello, World!"
 
       - name: Stop live-check
+        id: live-check-stop
         if: always()
         uses: open-telemetry/weaver/.github/actions/weaver-live-check-stop@adcf6fda79c3df1cb537669442aef753b7019777 # v0.24.2
         with:
           fail-on: violation
+
+      - name: Print live-check result
+        if: always()
+        run: |
+          echo "Weaver live-check result:"
+          echo "  samples:      ${{ steps.live-check-stop.outputs.samples }}"
+          echo "  violations:   ${{ steps.live-check-stop.outputs.violations }}"
+          echo "  improvements: ${{ steps.live-check-stop.outputs.improvements }}"
+          echo "  information:  ${{ steps.live-check-stop.outputs.informations }}"
+          echo
+          echo "See the job summary for finding messages and download the weaver-live-check-report artifact for the full JSON report."

--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ This repository includes GitHub Actions workflows that demonstrate how to use We
 - **[Validate Examples](.github/workflows/validate-examples.yml)** - Validates semantic convention models and policies
 - **[Check Generated Code](.github/workflows/check-generated-code.yml)** - Ensures generated code stays in sync with models
 - **[Check Documentation](.github/workflows/check-docs.yml)** - Ensures generated documentation stays in sync with models
+- **[Live Check Basic Example](.github/workflows/live-check-basic.yml)** - Runs the basic example against the Weaver live-check GitHub Actions
 
-These workflows use the [`setup-weaver`](https://github.com/open-telemetry/weaver/tree/main/.github/actions/setup-weaver) action to install Weaver. You can copy these patterns to your own repositories.
+These workflows use the [`setup-weaver`](https://github.com/open-telemetry/weaver/tree/main/.github/actions/setup-weaver), [`weaver-live-check-start`](https://github.com/open-telemetry/weaver/tree/main/.github/actions/weaver-live-check-start), and [`weaver-live-check-stop`](https://github.com/open-telemetry/weaver/tree/main/.github/actions/weaver-live-check-stop) actions. You can copy these patterns to your own repositories.
 
 ## Examples
 

--- a/basic/README.md
+++ b/basic/README.md
@@ -60,6 +60,8 @@ The application has been contrived so you can provoke a violation in `live-check
 
 The `live-check.rs` unit test checks for pass and fail by providing strings and ints as above.
 
+The [Live Check Basic Example](../.github/workflows/live-check-basic.yml) workflow shows the same application-level validation pattern in GitHub Actions using `weaver-live-check-start` and `weaver-live-check-stop`.
+
 ### Use live-check on the command line
 
 `weaver registry live-check -r model --inactivity-timeout 20`


### PR DESCRIPTION
Adds a basic GitHub Actions workflow that demonstrates `weaver-live-check-start` and `weaver-live-check-stop` against the basic example.

Follow-up from https://github.com/open-telemetry/weaver/pull/1564#issuecomment-4888095594.